### PR TITLE
add axis flag to json function

### DIFF
--- a/echarts/__init__.py
+++ b/echarts/__init__.py
@@ -25,14 +25,17 @@ __author__ = 'Hsiaoming Yang <me@lepture.com>'
 
 
 class Echart(Base):
-    def __init__(self, title, description=None, **kwargs):
+    def __init__(self, title, description=None, axis=True, **kwargs):
         self.title = {
             'text': title,
             'subtext': description,
         }
 
-        self.x_axis = []
-        self.y_axis = []
+        self.axis = axis
+        if self.axis:
+            self.x_axis = []
+            self.y_axis = []
+
         self.series = []
 
         self.logger = logging.getLogger(__name__)
@@ -61,21 +64,16 @@ class Echart(Base):
         return self.series
 
     @property
-    def json(self, axis=True):
-        """JSON format data.
-
-        Keyword Arguments:
-        axis -- type boolean, axis need or not (defautl: 'True')
-        """
+    def json(self):
+        """JSON format data."""
         json = {
             'title': self.title,
             'series': list(map(dict, self.series)),
         }
 
-        if axis:
+        if self.axis:
             json['xAxis'] = list(map(dict, self.x_axis)) or {}
             json['yAxis'] = list(map(dict, self.y_axis)) or {}
-
         if not hasattr(self, 'legend'):
             self.legend = Legend(list(map(lambda o: o.name, self.data)))
 

--- a/echarts/__init__.py
+++ b/echarts/__init__.py
@@ -61,14 +61,20 @@ class Echart(Base):
         return self.series
 
     @property
-    def json(self):
-        """JSON format data."""
+    def json(self, axis=True):
+        """JSON format data.
+
+        Keyword Arguments:
+        axis -- type boolean, axis need or not (defautl: 'True')
+        """
         json = {
             'title': self.title,
-            'xAxis': list(map(dict, self.x_axis)) or {},
-            'yAxis': list(map(dict, self.y_axis)) or {},
             'series': list(map(dict, self.series)),
         }
+
+        if axis:
+            json['xAxis'] = list(map(dict, self.x_axis)) or {}
+            json['yAxis'] = list(map(dict, self.y_axis)) or {}
 
         if not hasattr(self, 'legend'):
             self.legend = Legend(list(map(lambda o: o.name, self.data)))


### PR DESCRIPTION
Add axis flag to json function

For example, the [pie example](http://echarts.baidu.com/gallery/editor.html?c=doc-example/tutorial-styling-step5) in echarts has no axis items in json.

With the axis flag set to False, I needn't to delete the axis item in javascript.